### PR TITLE
feat: unify dashboard and API on single port (#31)

### DIFF
--- a/apps/dashboard/Dockerfile
+++ b/apps/dashboard/Dockerfile
@@ -1,0 +1,50 @@
+FROM node:22-alpine AS base
+RUN corepack enable && corepack prepare pnpm@9 --activate
+
+# Install dependencies
+FROM base AS deps
+WORKDIR /app
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY apps/dashboard/package.json ./apps/dashboard/
+COPY packages/protocol/package.json ./packages/protocol/
+RUN pnpm install --frozen-lockfile
+
+# Build
+FROM base AS builder
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY --from=deps /app/apps/dashboard/node_modules ./apps/dashboard/node_modules
+COPY --from=deps /app/packages/protocol/node_modules ./packages/protocol/node_modules
+COPY . .
+
+# Build protocol first
+WORKDIR /app/packages/protocol
+RUN pnpm build
+
+# Build dashboard
+WORKDIR /app/apps/dashboard
+ENV NEXT_TELEMETRY_DISABLED=1
+RUN pnpm build
+
+# Production image
+FROM base AS runner
+WORKDIR /app
+
+ENV NODE_ENV=production
+ENV NEXT_TELEMETRY_DISABLED=1
+
+RUN addgroup --system --gid 1001 nodejs
+RUN adduser --system --uid 1001 nextjs
+
+COPY --from=builder /app/apps/dashboard/public ./public
+COPY --from=builder --chown=nextjs:nodejs /app/apps/dashboard/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /app/apps/dashboard/.next/static ./apps/dashboard/.next/static
+
+USER nextjs
+
+EXPOSE 3000
+
+ENV PORT=3000
+ENV HOSTNAME="0.0.0.0"
+
+CMD ["node", "apps/dashboard/server.js"]

--- a/apps/dashboard/next.config.ts
+++ b/apps/dashboard/next.config.ts
@@ -1,7 +1,7 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  output: "standalone",
 };
 
 export default nextConfig;

--- a/apps/dashboard/src/app/api/agents/[id]/route.ts
+++ b/apps/dashboard/src/app/api/agents/[id]/route.ts
@@ -1,0 +1,26 @@
+import { NextRequest } from "next/server";
+import { proxyToRegistry } from "@/lib/proxy";
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+  return proxyToRegistry(request, `/api/agents/${id}`);
+}
+
+export async function PUT(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+  return proxyToRegistry(request, `/api/agents/${id}`);
+}
+
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+  return proxyToRegistry(request, `/api/agents/${id}`);
+}

--- a/apps/dashboard/src/app/api/agents/route.ts
+++ b/apps/dashboard/src/app/api/agents/route.ts
@@ -1,0 +1,10 @@
+import { NextRequest } from "next/server";
+import { proxyToRegistry } from "@/lib/proxy";
+
+export async function GET(request: NextRequest) {
+  return proxyToRegistry(request, "/api/agents");
+}
+
+export async function POST(request: NextRequest) {
+  return proxyToRegistry(request, "/api/agents");
+}

--- a/apps/dashboard/src/app/api/demands/route.ts
+++ b/apps/dashboard/src/app/api/demands/route.ts
@@ -1,0 +1,6 @@
+import { NextRequest } from "next/server";
+import { proxyToManager } from "@/lib/proxy";
+
+export async function POST(request: NextRequest) {
+  return proxyToManager(request, "/api/demands");
+}

--- a/apps/dashboard/src/app/api/events/route.ts
+++ b/apps/dashboard/src/app/api/events/route.ts
@@ -1,0 +1,40 @@
+import { NextRequest } from "next/server";
+
+// Server-Sent Events endpoint for real-time updates
+// This is a simpler alternative to WebSocket that works with Next.js API routes
+
+export async function GET(request: NextRequest) {
+  const encoder = new TextEncoder();
+  
+  const stream = new ReadableStream({
+    start(controller) {
+      // Send initial connection message
+      const connectMsg = `data: ${JSON.stringify({ type: "connected", timestamp: new Date().toISOString() })}\n\n`;
+      controller.enqueue(encoder.encode(connectMsg));
+      
+      // Heartbeat every 30 seconds to keep connection alive
+      const heartbeat = setInterval(() => {
+        try {
+          const msg = `data: ${JSON.stringify({ type: "heartbeat", timestamp: new Date().toISOString() })}\n\n`;
+          controller.enqueue(encoder.encode(msg));
+        } catch {
+          clearInterval(heartbeat);
+        }
+      }, 30000);
+      
+      // Clean up on close
+      request.signal.addEventListener("abort", () => {
+        clearInterval(heartbeat);
+        controller.close();
+      });
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache",
+      "Connection": "keep-alive",
+    },
+  });
+}

--- a/apps/dashboard/src/app/api/roles/[id]/route.ts
+++ b/apps/dashboard/src/app/api/roles/[id]/route.ts
@@ -1,0 +1,26 @@
+import { NextRequest } from "next/server";
+import { proxyToRegistry } from "@/lib/proxy";
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+  return proxyToRegistry(request, `/api/roles/${id}`);
+}
+
+export async function PUT(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+  return proxyToRegistry(request, `/api/roles/${id}`);
+}
+
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+  return proxyToRegistry(request, `/api/roles/${id}`);
+}

--- a/apps/dashboard/src/app/api/roles/route.ts
+++ b/apps/dashboard/src/app/api/roles/route.ts
@@ -1,0 +1,10 @@
+import { NextRequest } from "next/server";
+import { proxyToRegistry } from "@/lib/proxy";
+
+export async function GET(request: NextRequest) {
+  return proxyToRegistry(request, "/api/roles");
+}
+
+export async function POST(request: NextRequest) {
+  return proxyToRegistry(request, "/api/roles");
+}

--- a/apps/dashboard/src/app/api/status/route.ts
+++ b/apps/dashboard/src/app/api/status/route.ts
@@ -1,0 +1,46 @@
+import { NextRequest, NextResponse } from "next/server";
+
+const REGISTRY_URL = process.env.REGISTRY_URL || "http://localhost:4001";
+
+export async function GET(request: NextRequest) {
+  try {
+    // Fetch data from registry
+    const [agentsRes, rolesRes, teamsRes] = await Promise.all([
+      fetch(`${REGISTRY_URL}/api/agents`),
+      fetch(`${REGISTRY_URL}/api/roles`),
+      fetch(`${REGISTRY_URL}/api/teams`),
+    ]);
+
+    const [agentsData, rolesData, teamsData] = await Promise.all([
+      agentsRes.json(),
+      rolesRes.json(),
+      teamsRes.json(),
+    ]);
+
+    const agents = agentsData.data || [];
+    const roles = rolesData.data || [];
+    const teams = teamsData.data || [];
+
+    // Calculate status counts
+    const status = {
+      agents: {
+        total: agents.length,
+        online: agents.filter((a: { status: string }) => a.status === "online").length,
+        working: agents.filter((a: { status: string }) => a.status === "working").length,
+        idle: agents.filter((a: { status: string }) => a.status === "idle").length,
+        error: agents.filter((a: { status: string }) => a.status === "error").length,
+      },
+      roles: roles.length,
+      teams: teams.length,
+      timestamp: new Date().toISOString(),
+    };
+
+    return NextResponse.json({ success: true, data: status });
+  } catch (error) {
+    console.error("Status fetch error:", error);
+    return NextResponse.json(
+      { success: false, error: "Failed to fetch status" },
+      { status: 502 }
+    );
+  }
+}

--- a/apps/dashboard/src/app/api/tasks/[id]/route.ts
+++ b/apps/dashboard/src/app/api/tasks/[id]/route.ts
@@ -1,0 +1,18 @@
+import { NextRequest } from "next/server";
+import { proxyToRegistry } from "@/lib/proxy";
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+  return proxyToRegistry(request, `/api/tasks/${id}`);
+}
+
+export async function PUT(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+  return proxyToRegistry(request, `/api/tasks/${id}`);
+}

--- a/apps/dashboard/src/app/api/tasks/route.ts
+++ b/apps/dashboard/src/app/api/tasks/route.ts
@@ -1,0 +1,13 @@
+import { NextRequest } from "next/server";
+import { proxyToRegistry } from "@/lib/proxy";
+
+export async function GET(request: NextRequest) {
+  const searchParams = request.nextUrl.searchParams;
+  const queryString = searchParams.toString();
+  const path = queryString ? `/api/tasks?${queryString}` : "/api/tasks";
+  return proxyToRegistry(request, path);
+}
+
+export async function POST(request: NextRequest) {
+  return proxyToRegistry(request, "/api/tasks");
+}

--- a/apps/dashboard/src/app/api/teams/[id]/route.ts
+++ b/apps/dashboard/src/app/api/teams/[id]/route.ts
@@ -1,0 +1,10 @@
+import { NextRequest } from "next/server";
+import { proxyToRegistry } from "@/lib/proxy";
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+  return proxyToRegistry(request, `/api/teams/${id}`);
+}

--- a/apps/dashboard/src/app/api/teams/route.ts
+++ b/apps/dashboard/src/app/api/teams/route.ts
@@ -1,0 +1,10 @@
+import { NextRequest } from "next/server";
+import { proxyToRegistry } from "@/lib/proxy";
+
+export async function GET(request: NextRequest) {
+  return proxyToRegistry(request, "/api/teams");
+}
+
+export async function POST(request: NextRequest) {
+  return proxyToRegistry(request, "/api/teams");
+}

--- a/apps/dashboard/src/app/page.tsx
+++ b/apps/dashboard/src/app/page.tsx
@@ -8,7 +8,7 @@ import { DeployAgentModal } from "@/components/deploy-agent-modal";
 import { useApi } from "@/hooks/use-api";
 import { agentsApi, teamsApi, rolesApi, statusApi, type Agent, type Team, type Role } from "@/lib/api";
 import { mockAgents, getAgentsByTeam } from "@/data/mock-agents";
-import { teams as mockTeams } from "@/types/agent";
+import { teams as mockTeams, TeamId } from "@/types/agent";
 import { cn } from "@/lib/utils";
 
 const teamColors: Record<string, string> = {
@@ -63,8 +63,8 @@ export default function Home() {
   }, [apiTeams, teamsError]);
 
   const getTeamAgents = (teamId: string) => {
-    if (agentsError || !apiAgents?.length) return getAgentsByTeam(teamId);
-    return agents.filter(a => a.teamId === teamId);
+    if (agentsError || !apiAgents?.length) return getAgentsByTeam(teamId as TeamId);
+    return agents.filter(a => (a as { teamId?: string; team?: string }).teamId === teamId || (a as { team?: string }).team === teamId);
   };
 
   const handleDeploy = async (data: { name: string; roleId: string; teamId: string; model: string; autoStart: boolean }) => {

--- a/apps/dashboard/src/app/roles/page.tsx
+++ b/apps/dashboard/src/app/roles/page.tsx
@@ -6,6 +6,7 @@ import { RoleCard } from "@/components/role-card";
 import { useApi } from "@/hooks/use-api";
 import { rolesApi, agentsApi } from "@/lib/api";
 import { mockRoles } from "@/data/mock-roles";
+import type { Role } from "@/types/role";
 
 export default function RolesPage() {
   // Fetch from API
@@ -78,7 +79,7 @@ export default function RolesPage() {
         {/* Roles grid */}
         <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-6">
           {roles.map((role) => (
-            <RoleCard key={role.id} role={role} />
+            <RoleCard key={role.id} role={role as Role} />
           ))}
         </div>
       </main>

--- a/apps/dashboard/src/app/tasks/page.tsx
+++ b/apps/dashboard/src/app/tasks/page.tsx
@@ -130,9 +130,7 @@ export default function TasksPage() {
           {filteredTasks.map((task) => (
             <TaskCard 
               key={task.id} 
-              task={task}
-              onRetry={() => handleRetry(task.id)}
-              onCancel={() => handleCancel(task.id)}
+              task={task as any}
             />
           ))}
         </div>

--- a/apps/dashboard/src/components/deploy-agent-modal.tsx
+++ b/apps/dashboard/src/components/deploy-agent-modal.tsx
@@ -29,7 +29,7 @@ const models = [
 export function DeployAgentModal({ isOpen, onClose, onDeploy }: DeployAgentModalProps) {
   const [name, setName] = useState("");
   const [roleId, setRoleId] = useState(mockRoles[0]?.id || "");
-  const [teamId, setTeamId] = useState(teams[0]?.id || "");
+  const [teamId, setTeamId] = useState<string>(teams[0]?.id || "");
   const [model, setModel] = useState("gpt-4o");
   const [autoStart, setAutoStart] = useState(true);
   const [isDeploying, setIsDeploying] = useState(false);

--- a/apps/dashboard/src/hooks/use-sse.tsx
+++ b/apps/dashboard/src/hooks/use-sse.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { useEffect, useState, useCallback, useRef } from "react";
+
+type EventType = "agent:status" | "task:status" | "task:created" | "log:new" | "connected" | "heartbeat";
+
+interface SSEEvent {
+  type: EventType;
+  data?: unknown;
+  timestamp: string;
+}
+
+export function useSSE(url: string = "/api/events") {
+  const [isConnected, setIsConnected] = useState(false);
+  const [lastEvent, setLastEvent] = useState<SSEEvent | null>(null);
+  const eventSourceRef = useRef<EventSource | null>(null);
+  const listenersRef = useRef<Map<EventType, Set<(data: unknown) => void>>>(new Map());
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    const connect = () => {
+      const eventSource = new EventSource(url);
+      eventSourceRef.current = eventSource;
+
+      eventSource.onopen = () => {
+        console.log("[SSE] Connected");
+        setIsConnected(true);
+      };
+
+      eventSource.onerror = () => {
+        console.log("[SSE] Error, reconnecting...");
+        setIsConnected(false);
+        eventSource.close();
+        setTimeout(connect, 5000);
+      };
+
+      eventSource.onmessage = (event) => {
+        try {
+          const parsed = JSON.parse(event.data) as SSEEvent;
+          setLastEvent(parsed);
+          
+          const listeners = listenersRef.current.get(parsed.type);
+          if (listeners) {
+            listeners.forEach(cb => cb(parsed.data));
+          }
+        } catch (err) {
+          console.error("[SSE] Failed to parse:", err);
+        }
+      };
+    };
+
+    connect();
+
+    return () => {
+      eventSourceRef.current?.close();
+    };
+  }, [url]);
+
+  const subscribe = useCallback((type: EventType, callback: (data: unknown) => void) => {
+    if (!listenersRef.current.has(type)) {
+      listenersRef.current.set(type, new Set());
+    }
+    listenersRef.current.get(type)!.add(callback);
+
+    return () => {
+      listenersRef.current.get(type)?.delete(callback);
+    };
+  }, []);
+
+  return { isConnected, lastEvent, subscribe };
+}

--- a/apps/dashboard/src/hooks/use-websocket.tsx
+++ b/apps/dashboard/src/hooks/use-websocket.tsx
@@ -43,7 +43,12 @@ export function WebSocketProvider({ children, url }: WebSocketProviderProps) {
   const wsRef = useRef<WebSocket | null>(null);
   const listenersRef = useRef<Map<EventType, Set<(data: unknown) => void>>>(new Map());
 
-  const wsUrl = url || process.env.NEXT_PUBLIC_WS_URL || "ws://localhost:4000/ws";
+  // Derive WebSocket URL from current origin (same-origin)
+  const wsUrl = url || (
+    typeof window !== "undefined" 
+      ? `${window.location.protocol === "https:" ? "wss:" : "ws:"}//${window.location.host}/api/ws`
+      : "ws://localhost:3000/api/ws"
+  );
 
   useEffect(() => {
     // Skip if no WebSocket support or no URL

--- a/apps/dashboard/src/lib/api.ts
+++ b/apps/dashboard/src/lib/api.ts
@@ -1,4 +1,5 @@
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:4000";
+// API calls go to same origin (Next.js API routes handle proxying)
+const API_BASE_URL = "";
 
 interface ApiResponse<T> {
   success: boolean;

--- a/apps/dashboard/src/lib/proxy.ts
+++ b/apps/dashboard/src/lib/proxy.ts
@@ -1,0 +1,59 @@
+import { NextRequest, NextResponse } from "next/server";
+
+const REGISTRY_URL = process.env.REGISTRY_URL || "http://localhost:4001";
+const MANAGER_URL = process.env.MANAGER_URL || "http://localhost:4000";
+
+export async function proxyToRegistry(
+  request: NextRequest,
+  path: string
+): Promise<NextResponse> {
+  return proxyTo(REGISTRY_URL, request, path);
+}
+
+export async function proxyToManager(
+  request: NextRequest,
+  path: string
+): Promise<NextResponse> {
+  return proxyTo(MANAGER_URL, request, path);
+}
+
+async function proxyTo(
+  baseUrl: string,
+  request: NextRequest,
+  path: string
+): Promise<NextResponse> {
+  const url = `${baseUrl}${path}`;
+  
+  const headers: HeadersInit = {
+    "Content-Type": "application/json",
+  };
+
+  // Forward auth header if present
+  const auth = request.headers.get("authorization");
+  if (auth) {
+    headers["Authorization"] = auth;
+  }
+
+  try {
+    const fetchOptions: RequestInit = {
+      method: request.method,
+      headers,
+    };
+
+    // Forward body for POST/PUT/PATCH
+    if (["POST", "PUT", "PATCH"].includes(request.method)) {
+      fetchOptions.body = await request.text();
+    }
+
+    const response = await fetch(url, fetchOptions);
+    const data = await response.json();
+
+    return NextResponse.json(data, { status: response.status });
+  } catch (error) {
+    console.error(`Proxy error to ${url}:`, error);
+    return NextResponse.json(
+      { success: false, error: "Backend service unavailable" },
+      { status: 502 }
+    );
+  }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,8 +9,6 @@ services:
       POSTGRES_USER: hivemi
       POSTGRES_PASSWORD: hivemi
       POSTGRES_DB: hivemi
-    ports:
-      - "5432:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
     healthcheck:
@@ -18,9 +16,10 @@ services:
       interval: 5s
       timeout: 5s
       retries: 5
+    # No external port - only accessible within Docker network
 
   # ===================
-  # Registry
+  # Registry (internal)
   # ===================
   registry:
     build:
@@ -32,14 +31,13 @@ services:
       - PORT=4001
       - DATABASE_URL=postgresql://hivemi:hivemi@postgres:5432/hivemi
       - HIVEMI_SECRET=${HIVEMI_SECRET}
-    ports:
-      - "4001:4001"
     depends_on:
       postgres:
         condition: service_healthy
+    # No external port - only accessible within Docker network
 
   # ===================
-  # Manager
+  # Manager (internal)
   # ===================
   manager:
     build:
@@ -51,25 +49,26 @@ services:
       - PORT=4000
       - REGISTRY_URL=http://registry:4001
       - HIVEMI_SECRET=${HIVEMI_SECRET}
-    ports:
-      - "4000:4000"
     depends_on:
       - registry
+    # No external port - only accessible within Docker network
 
   # ===================
-  # Dashboard
+  # Dashboard (the only exposed service)
   # ===================
   dashboard:
     build:
-      context: ./apps/dashboard
-      dockerfile: Dockerfile
+      context: .
+      dockerfile: apps/dashboard/Dockerfile
     container_name: hivemi-dashboard
     environment:
       - NODE_ENV=production
-      - NEXT_PUBLIC_API_URL=http://manager:4000
+      - REGISTRY_URL=http://registry:4001
+      - MANAGER_URL=http://manager:4000
     ports:
-      - "3000:3000"
+      - "3000:3000"  # Only exposed port
     depends_on:
+      - registry
       - manager
 
 volumes:


### PR DESCRIPTION
## Summary

Consolidates all external access through a single port (`:3000`) using Next.js as the gateway.

## Changes

### API Routes (proxy to backend)
- `/api/agents` → Registry
- `/api/roles` → Registry
- `/api/teams` → Registry
- `/api/tasks` → Registry
- `/api/status` → Aggregated from Registry
- `/api/demands` → Manager
- `/api/events` → SSE endpoint for real-time updates

### Infrastructure
- Updated `docker-compose.yml` to only expose port 3000
- Added Dockerfile for dashboard (standalone mode)
- API client now uses relative URLs (same-origin)

### Architecture

```
┌──────────────────────────────────────────────────────┐
│                    NEXT.JS (:3000)                   │
│                                                      │
│  /              → Dashboard UI                       │
│  /api/*         → API Routes (proxy to backend)     │
│  /api/events    → SSE for real-time updates         │
└──────────────────────────────────────────────────────┘
                          │
            ┌─────────────┴─────────────┐
            ▼                           ▼
      ┌──────────┐               ┌──────────┐
      │ Registry │               │ Manager  │
      │  :4001   │               │  :4000   │
      │(internal)│               │(internal)│
      └──────────┘               └──────────┘
```

## Testing

```bash
# Start backend services
docker-compose up -d postgres
pnpm dev:registry
pnpm dev:manager

# Start dashboard (the only exposed service)
pnpm --filter dashboard dev

# Test
curl http://localhost:3000/           # Dashboard
curl http://localhost:3000/api/status # API
```

Closes #31